### PR TITLE
Fixed issue where training app wouldn't compile on mac

### DIFF
--- a/framework/SwiftOCR/SwiftOCR.swift
+++ b/framework/SwiftOCR/SwiftOCR.swift
@@ -577,7 +577,14 @@ open class SwiftOCR {
             dodgeBlendFilter.useNextFrameForImageCapture()
             image?.processImage()
             
-            var processedImage:OCRImage? = dodgeBlendFilter.imageFromCurrentFramebuffer(with: UIImage.Orientation.up)
+            #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+            let orientationUp = UIImage.Orientation.up
+            #else
+            //GPUImage is using a re-definition of the UIImageOrientation for Mac compilation
+            let orientationUp = UIImageOrientation.up
+            #endif
+            
+            var processedImage:OCRImage? = dodgeBlendFilter.imageFromCurrentFramebuffer(with: orientationUp)
             
             while processedImage?.size == CGSize.zero || processedImage == nil {
                 dodgeBlendFilter.useNextFrameForImageCapture()
@@ -619,7 +626,14 @@ open class SwiftOCR {
         thresholdFilter.useNextFrameForImageCapture()
         picture?.processImage()
         
-        var processedImage:OCRImage? = thresholdFilter.imageFromCurrentFramebuffer(with: UIImage.Orientation.up)
+        #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+        let orientationUp = UIImage.Orientation.up
+        #else
+        //GPUImage is using a re-definition of the UIImageOrientation for Mac compilation
+        let orientationUp = UIImageOrientation.up
+        #endif
+        
+        var processedImage:OCRImage? = thresholdFilter.imageFromCurrentFramebuffer(with: orientationUp)
         
         while processedImage == nil || processedImage?.size == CGSize.zero {
             thresholdFilter.useNextFrameForImageCapture()


### PR DESCRIPTION
The GPUImage library redefines the "UIImageOrientation" definition when compiled on MacOS, since MacOS applications aren't built with UIKit. Unfortunately GPUImage did not make the naming changes that affected the UIImageOrientation enum (e.g. UIImageOrientation.up -> UIImage.Orientation.Up).

Since the training app is built on MacOS, the recent change to update the SwiftOCR library to Swift 4.2 broke it. I have put in a few ifdef statements to account for this.

Fixes #153 