### PR TITLE
SwiftOCR Camera: Swift 5 fixes

### DIFF
--- a/framework/SwiftOCR/SwiftOCR.swift
+++ b/framework/SwiftOCR/SwiftOCR.swift
@@ -581,7 +581,7 @@ open class SwiftOCR {
             let orientationUp = UIImage.Orientation.up
             #else
             //GPUImage is using a re-definition of the UIImageOrientation for Mac compilation
-            let orientationUp = UIImageOrientation.up
+            let orientationUp = UIImage.Orientation.up
             #endif
             
             var processedImage:OCRImage? = dodgeBlendFilter.imageFromCurrentFramebuffer(with: orientationUp)
@@ -630,7 +630,7 @@ open class SwiftOCR {
         let orientationUp = UIImage.Orientation.up
         #else
         //GPUImage is using a re-definition of the UIImageOrientation for Mac compilation
-        let orientationUp = UIImageOrientation.up
+        let orientationUp = UIImage.Orientation.up
         #endif
         
         var processedImage:OCRImage? = thresholdFilter.imageFromCurrentFramebuffer(with: orientationUp)


### PR DESCRIPTION
SwiftOCR.swift#L584,633: Replace 'UIImageOrientation' with 'UIImage.Orientation'

UIImageOrientation is deprecated as of Swift 4.2, can't run SwiftOCR Camera example without these changes.